### PR TITLE
Upgrade node (Docker) and socketcluster-server (npm)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM node:6.3.0-slim
+FROM node:8.4.0-slim
 MAINTAINER Jonathan Gros-Dubois
 
-LABEL version="1.2.0"
+LABEL version="1.5.1"
 LABEL description="Docker file for SCC State Server"
 
 RUN mkdir -p /usr/src/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scc-state",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Cluster state tracking and notification engine for SocketCluster clusters.",
   "main": "server.js",
   "scripts": {
@@ -25,6 +25,6 @@
   "dependencies": {
     "lodash": "4.13.1",
     "minimist": "1.2.0",
-    "socketcluster-server": "~6.3.0"
+    "socketcluster-server": "~7.0.2"
   }
 }


### PR DESCRIPTION
Hi,

Made a PR to upgrade scc-state. Use newer node base-image in Dockerfile and upgrade the npm version of socketcluster-server