### PR TITLE
Bump Node to 8-LTS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8.4.0-slim
+FROM node:8-slim
 MAINTAINER Jonathan Gros-Dubois
 
 LABEL version="1.5.1"


### PR DESCRIPTION
Use tag :8-slim since version 8 of Node now is LTS:
https://github.com/nodejs/Release