### PR TITLE
fix: print instancePort for worker on join/leave

### DIFF
--- a/server.js
+++ b/server.js
@@ -113,7 +113,7 @@ var sccBrokerLeaveCluster = function (socket, respond) {
 var sccWorkerLeaveCluster = function (socket, respond) {
   delete sccWorkerSockets[socket.id];
   respond && respond();
-  logInfo(`The scc-worker instance ${socket.instanceId} at address ${socket.instanceIp} left the cluster on socket ${socket.id}`);
+  logInfo(`The scc-worker instance ${socket.instanceId} at address ${socket.instanceIp} on port ${socket.instancePort} left the cluster on socket ${socket.id}`);
 };
 
 var sendEventToInstance = function (socket, event, data) {

--- a/server.js
+++ b/server.js
@@ -224,7 +224,7 @@ scServer.on('connection', function (socket) {
 
     sccWorkerSockets[socket.id] = socket;
     respond(null, getSCCBrokerClusterState());
-    logInfo(`The scc-worker instance ${data.instanceId} at address ${socket.instanceIp} joined the cluster on socket ${socket.id}`);
+    logInfo(`The scc-worker instance ${data.instanceId} at address ${socket.instanceIp} on port ${socket.instancePort} joined the cluster on socket ${socket.id}`);
   });
 
   socket.on('sccWorkerLeaveCluster', function (respond) {


### PR DESCRIPTION
Useful if one overrides the default ports