### PR TITLE
feat(/status): new endpoint to query status of state

### DIFF
--- a/server.js
+++ b/server.js
@@ -52,7 +52,18 @@ let agServer = socketClusterServer.attach(httpServer);
   for await (let [req, res] of httpServer.listener('request')) {
     if (req.url === '/health-check') {
       res.writeHead(200, {'Content-Type': 'text/html'});
-      res.end('OK');
+      res.end("OK")
+    }
+    else if (req.url === '/status') {
+      res.writeHead(200, {'Content-Type': 'text/html'});
+      let statusObj = getSCCClusterState();
+      let status = {};
+
+      status.workers = statusObj.sccWorkerURIs;
+      status.brokers = statusObj.sccBrokerURIs;
+      status.time = statusObj.time;
+
+      res.end(JSON.stringify(status));
     } else {
       res.writeHead(404, {'Content-Type': 'text/html'});
       res.end('Not found');


### PR DESCRIPTION
Suggestion to add new /status endpoint to be able to query scc-state of which endpoints it knows of.

Query to the endpoints returns:
`{
  "workers": [
    "ws://[::ffff:127.0.0.1]:8000"
  ],
  "brokers": [
    "ws://[::ffff:127.0.0.1]:8888",
    "ws://[::ffff:127.0.0.1]:9999"
  ],
  "time": 1582717713041
}
`

I would use this to add additional monitoring and also observability.

Hope this could be added @jondubois 